### PR TITLE
Fix typographical error `Lancher` → `Launcher`

### DIFF
--- a/Example.swiftpm/App.swift
+++ b/Example.swiftpm/App.swift
@@ -27,7 +27,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
 final class SceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
     var window: UIWindow?
-    var lancherWindow: UIWindow? = nil
+    var launcherWindow: UIWindow? = nil
     
     func scene(
         _ scene: UIScene,
@@ -36,9 +36,9 @@ final class SceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
     ) {
         let windowScene = scene as! UIWindowScene
         window = windowScene.keyWindow
-        lancherWindow = LancherHostingWindow(
+        launcherWindow = LauncherHostingWindow(
             windowScene: windowScene,
-            content: LancherContentView()
+            content: LauncherContentView()
         )
     }
 }

--- a/Example.swiftpm/LauncherContentView.swift
+++ b/Example.swiftpm/LauncherContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct LancherContentView: View {
+struct LauncherContentView: View {
     var body: some View {
         NavigationView {
             List {

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ dependencies: [
 # Usage
 
 ```swift
-lancherWindow = LancherHostingWindow(
+launcherWindow = LauncherHostingWindow(
     windowScene: windowScene,
-    content: LancherContentView()
+    content: LauncherContentView()
 )
 ```
 

--- a/Sources/ContentLauncher/LauncherButtonInteraction.swift
+++ b/Sources/ContentLauncher/LauncherButtonInteraction.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class LancherButtonInteraction: NSObject, UIInteraction {
+final class LauncherButtonInteraction: NSObject, UIInteraction {
     weak var view: UIView?
     
     var centerXConstraint: NSLayoutConstraint!

--- a/Sources/ContentLauncher/LauncherHostViewController.swift
+++ b/Sources/ContentLauncher/LauncherHostViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
 import SwiftUI
 
-final class LancherHostViewController<Content: View>: UIViewController {
-    let button = UIButton(configuration: .lancher())
+final class LauncherHostViewController<Content: View>: UIViewController {
+    let button = UIButton(configuration: .launcher())
     let content: Content
     
     init(content: Content) {
@@ -24,7 +24,7 @@ final class LancherHostViewController<Content: View>: UIViewController {
             presentContent()
         }, for: .primaryActionTriggered)
         
-        button.addInteraction(LancherButtonInteraction())
+        button.addInteraction(LauncherButtonInteraction())
     }
     
     func presentContent() {

--- a/Sources/ContentLauncher/LauncherHostingWindow.swift
+++ b/Sources/ContentLauncher/LauncherHostingWindow.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import UIKit
 
-public final class LancherHostingWindow<Content: View>: UIWindow {
+public final class LauncherHostingWindow<Content: View>: UIWindow {
     public init(
         windowScene: UIWindowScene,
         content: Content
     ) {
         super.init(windowScene: windowScene)
-        rootViewController = LancherHostViewController(content: content)
+        rootViewController = LauncherHostViewController(content: content)
         isHidden = false // visibleWithoutMakeKey
     }
     
@@ -33,3 +33,5 @@ public final class LancherHostingWindow<Content: View>: UIWindow {
     }
 }
 
+@available(*, deprecated, renamed: "LauncherHostingWindow", message: "Use LauncherHostingWindow instead.")
+public typealias LancherHostingWindow = LauncherHostingWindow

--- a/Sources/ContentLauncher/LauncherHostingWindow.swift
+++ b/Sources/ContentLauncher/LauncherHostingWindow.swift
@@ -32,6 +32,3 @@ public final class LauncherHostingWindow<Content: View>: UIWindow {
         }
     }
 }
-
-@available(*, deprecated, renamed: "LauncherHostingWindow", message: "Use LauncherHostingWindow instead.")
-public typealias LancherHostingWindow = LauncherHostingWindow

--- a/Sources/ContentLauncher/UIButon.Configuration+.swift
+++ b/Sources/ContentLauncher/UIButon.Configuration+.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension UIButton.Configuration {
     @MainActor
-    static func lancher() -> UIButton.Configuration {
+    static func launcher() -> UIButton.Configuration {
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.background.visualEffect = UIBlurEffect(style: .systemMaterial)


### PR DESCRIPTION
Fix `Lancher` → `Launcher`.

~~`LancherHostingWindow`, which is `public`, should be deprecated to encourage auto-fix.~~