### PR TITLE
Add debug key window feature and restore previous key window on dismiss

### DIFF
--- a/Example.swiftpm/LauncherContentView.swift
+++ b/Example.swiftpm/LauncherContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct LauncherContentView: View {
     var body: some View {
@@ -11,6 +12,12 @@ struct LauncherContentView: View {
                 }
                 
                 Button {
+                    debugKeyWindow()
+                } label: {
+                    Text("Debug Key Window")
+                }
+                
+                Button {
                     exit(0)
                 } label: {
                     Text("Exit app")
@@ -18,6 +25,39 @@ struct LauncherContentView: View {
             }
             .navigationTitle("Debug Tools")
             .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+    
+    private func debugKeyWindow() {
+        print("Debug Key Window tapped - printing key window info in 3 seconds...")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            guard let keyWindow = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows
+                .first(where: { $0.isKeyWindow }) else {
+                print("No key window found")
+                return
+            }
+            
+            print("=== Key Window Debug Info ===")
+            print("Window: \(keyWindow)")
+            print("Frame: \(keyWindow.frame)")
+            print("Bounds: \(keyWindow.bounds)")
+            print("Safe Area Insets: \(keyWindow.safeAreaInsets)")
+            print("Root View Controller: \(String(describing: keyWindow.rootViewController))")
+            print("Window Level: \(keyWindow.windowLevel)")
+            print("Is Key Window: \(keyWindow.isKeyWindow)")
+            print("Is Hidden: \(keyWindow.isHidden)")
+            print("Alpha: \(keyWindow.alpha)")
+            print("Transform: \(keyWindow.transform)")
+            
+            if let rootVC = keyWindow.rootViewController {
+                print("Root VC View Frame: \(rootVC.view.frame)")
+                print("Root VC View Bounds: \(rootVC.view.bounds)")
+            }
+            
+            print("=============================")
         }
     }
 }

--- a/Sources/ContentLauncher/LauncherHostViewController.swift
+++ b/Sources/ContentLauncher/LauncherHostViewController.swift
@@ -1,16 +1,19 @@
 import UIKit
 import SwiftUI
 
-final class LauncherHostViewController<Content: View>: UIViewController {
+final class LauncherHostViewController<Content: View>: UIViewController, UIAdaptivePresentationControllerDelegate {
     let button: UIButton
     let content: Content
+    let onDismiss: (() -> Void)?
     
     init(
         content: Content,
-        buttonConfiguration: UIButton.Configuration
+        buttonConfiguration: UIButton.Configuration,
+        onDismiss: (() -> Void)? = nil
     ) {
         self.button = UIButton(configuration: buttonConfiguration)
         self.content = content
+        self.onDismiss = onDismiss
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -39,6 +42,13 @@ final class LauncherHostViewController<Content: View>: UIViewController {
         vc.sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
         vc.sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
         
-        present(vc, animated: true)
+        present(vc, animated: true) { [weak self] in
+            // Set up dismiss callback when presentation is complete
+            vc.presentationController?.delegate = self
+        }
+    }
+    
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismiss?()
     }
 }

--- a/Sources/ContentLauncher/LauncherHostingWindow.swift
+++ b/Sources/ContentLauncher/LauncherHostingWindow.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import UIKit
 
 public final class LauncherHostingWindow<Content: View>: UIWindow {
+    private weak var previousKeyWindow: UIWindow?
+    
     public init(
         windowScene: UIWindowScene,
         content: Content,
@@ -10,7 +12,10 @@ public final class LauncherHostingWindow<Content: View>: UIWindow {
         super.init(windowScene: windowScene)
         rootViewController = LauncherHostViewController(
             content: content,
-            buttonConfiguration: launcherButtonConfiguration
+            buttonConfiguration: launcherButtonConfiguration,
+            onDismiss: { [weak self] in
+                self?.restorePreviousKeyWindow()
+            }
         )
         isHidden = false // visibleWithoutMakeKey
     }
@@ -34,5 +39,19 @@ public final class LauncherHostingWindow<Content: View>: UIWindow {
                 return nil
             }
         }
+    }
+    
+    public override func makeKey() {
+        // Store the previous key window before becoming key
+        previousKeyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow && $0 !== self }
+        
+        super.makeKey()
+    }
+    
+    private func restorePreviousKeyWindow() {
+        previousKeyWindow?.makeKey()
     }
 }


### PR DESCRIPTION
## Summary
- Added debug key window button to LauncherContentView with 3-second delay to print key window information
- Implemented key window restoration functionality in LauncherHostingWindow when modal dismisses
- Store previous key window before becoming key and restore it on dismiss

## Changes
- **LauncherContentView.swift**: Added "Debug Key Window" button with 3-second delay that prints comprehensive key window information
- **LauncherHostingWindow.swift**: Added previousKeyWindow storage and restoration logic with makeKey() override
- **LauncherHostViewController.swift**: Added onDismiss callback and UIAdaptivePresentationControllerDelegate implementation

## Test plan
- [ ] Run the app and tap "Debug Key Window" button
- [ ] Verify key window information is printed after 3 seconds
- [ ] Open launcher modal and dismiss it
- [ ] Verify previous key window is restored correctly

🤖 Generated with [Claude Code](https://claude.ai/code)